### PR TITLE
fix: horizon client

### DIFF
--- a/examples/nativescript-ng2-chat-app/.vscode/launch.json
+++ b/examples/nativescript-ng2-chat-app/.vscode/launch.json
@@ -1,0 +1,85 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch on iOS Device",
+      "type": "nativescript",
+      "platform": "ios",
+      "request": "launch",
+      "appRoot": "${workspaceRoot}",
+      "sourceMaps": true,
+      "diagnosticLogging": false,
+      "emulator": false
+    },
+    {
+      "name": "Attach on iOS Device",
+      "type": "nativescript",
+      "platform": "ios",
+      "request": "attach",
+      "appRoot": "${workspaceRoot}",
+      "sourceMaps": true,
+      "diagnosticLogging": false,
+      "emulator": false
+    },
+    {
+      "name": "Launch on iOS Emulator",
+      "type": "nativescript",
+      "platform": "ios",
+      "request": "launch",
+      "appRoot": "${workspaceRoot}",
+      "sourceMaps": true,
+      "diagnosticLogging": false,
+      "emulator": true
+    },
+    {
+      "name": "Attach on iOS Emulator",
+      "type": "nativescript",
+      "platform": "ios",
+      "request": "attach",
+      "appRoot": "${workspaceRoot}",
+      "sourceMaps": true,
+      "diagnosticLogging": false,
+      "emulator": true
+    },
+    {
+      "name": "Launch on Android Device",
+      "type": "nativescript",
+      "platform": "android",
+      "request": "launch",
+      "appRoot": "${workspaceRoot}",
+      "sourceMaps": true,
+      "diagnosticLogging": false,
+      "emulator": false
+    },
+    {
+      "name": "Launch on Android Emulator",
+      "type": "nativescript",
+      "platform": "android",
+      "request": "launch",
+      "appRoot": "${workspaceRoot}",
+      "sourceMaps": true,
+      "diagnosticLogging": false,
+      "emulator": true
+    },
+    {
+      "name": "Attach on Android Device",
+      "type": "nativescript",
+      "platform": "android",
+      "request": "attach",
+      "appRoot": "${workspaceRoot}",
+      "sourceMaps": false,
+      "diagnosticLogging": false,
+      "emulator": false
+    },
+    {
+      "name": "Attach on Android Emulator",
+      "type": "nativescript",
+      "platform": "android",
+      "request": "attach",
+      "appRoot": "${workspaceRoot}",
+      "sourceMaps": false,
+      "diagnosticLogging": false,
+      "emulator": true
+    }
+  ]
+}

--- a/examples/nativescript-ng2-chat-app/.vscode/settings.json
+++ b/examples/nativescript-ng2-chat-app/.vscode/settings.json
@@ -1,0 +1,3 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+}

--- a/examples/nativescript-ng2-chat-app/app/components/chat/chat.component.html
+++ b/examples/nativescript-ng2-chat-app/app/components/chat/chat.component.html
@@ -1,18 +1,18 @@
-<h1>Messages</h1>
 <StackLayout>
     <StackLayout>
+        <Label text="Messages" textWrap="true"></Label>
         <TextField [(ngModel)]="newMessage"></TextField>
         <Button [text]="Send" (tap)="addMessage(newMessage)"></Button>
     </StackLayout>
     <GridLayout>
         <ListView [items]="messages">
             <template let-item="item">
-      <GridLayout>
-       <Image height="50" width="50" src="message.avatar"></Image>
-       <Label [text]="item.text"></Label>
-       <Label [text]="item.datetime"></Label>
-      </GridLayout>
-     </template>
+            <GridLayout>
+                <Image height="50" width="50" [src]="message.avatar"></Image>
+                <Label [text]="item.text"></Label>
+                <Label [text]="item.datetime"></Label>
+            </GridLayout>
+            </template>
         </ListView>
     </GridLayout>
 </StackLayout>

--- a/examples/nativescript-ng2-chat-app/app/components/chat/chat.component.ts
+++ b/examples/nativescript-ng2-chat-app/app/components/chat/chat.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {HorizonService} from '../../services/horizon.service';
 @Component({
-    selector: '<chat></chat>',
+    selector: 'chat',
     templateUrl : 'components/chat/chat.component.html',
     providers: [HorizonService]
 })

--- a/examples/nativescript-ng2-chat-app/app/main.ts
+++ b/examples/nativescript-ng2-chat-app/app/main.ts
@@ -1,5 +1,6 @@
 // this import should be first in order to load some required settings (like globals and reflect-metadata)
 import {nativeScriptBootstrap} from "nativescript-angular/application";
+import {HTTP_PROVIDERS} from '@angular/http';
 import {AppComponent} from "./app.component";
 
-nativeScriptBootstrap(AppComponent);
+nativeScriptBootstrap(AppComponent, [HTTP_PROVIDERS]);

--- a/examples/nativescript-ng2-chat-app/app/package.json
+++ b/examples/nativescript-ng2-chat-app/app/package.json
@@ -25,19 +25,5 @@
 	"homepage": "https://github.com/NativeScript/template-hello-world-ng",
 	"android": {
 		"v8Flags": "--expose_gc"
-	},
-	"dependencies": {
-		"@angular/common": "2.0.0-rc.1",
-		"@angular/compiler": "2.0.0-rc.1",
-		"@angular/core": "2.0.0-rc.1",
-		"@angular/router-deprecated": "2.0.0-rc.1",
-		"@angular/platform-browser": "2.0.0-rc.1",
-		"@angular/platform-browser-dynamic": "2.0.0-rc.1",
-		"@angular/platform-server": "2.0.0-rc.1",
-		"nativescript-angular": "0.1.1",
-		"tns-core-modules": "^2.0.0"
-	},
-	"devDependencies": {
-		"nativescript-dev-typescript": "^0.3.2"
 	}
 }

--- a/examples/nativescript-ng2-chat-app/app/services/horizon.service.ts
+++ b/examples/nativescript-ng2-chat-app/app/services/horizon.service.ts
@@ -1,5 +1,5 @@
-declare var Horizon: any;
-import {Injectable} from '@angular/core'
+var Horizon = require('@horizon/client/dist/horizon');
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
 const SERVER_URL = 'http://192.168.56.1:8181' //Using genymotion
 
@@ -7,9 +7,9 @@ const SERVER_URL = 'http://192.168.56.1:8181' //Using genymotion
 export class HorizonService {
     private horizon;
     private chat;
-    avatar_url = `http://api.adorable.io/avatars/50/${new Date().getMilliseconds()}.png`;
+    private avatar_url = `http://api.adorable.io/avatars/50/${new Date().getMilliseconds()}.png`;
     constructor() {
-        this.horizon = Horizon({ host: SERVER_URL });
+        this.horizon = new Horizon({ host: SERVER_URL });
         this.chat = this.horizon("chat");
     }
     connect() {

--- a/examples/nativescript-ng2-chat-app/package.json
+++ b/examples/nativescript-ng2-chat-app/package.json
@@ -7,18 +7,24 @@
 		"id": "org.nativescript.nativescriptng2chatapp",
 		"tns-android": {
 			"version": "2.0.0"
+		},
+		"tns-ios": {
+			"version": "2.0.0"
 		}
 	},
 	"dependencies": {
 		"@angular/common": "2.0.0-rc.1",
 		"@angular/compiler": "2.0.0-rc.1",
 		"@angular/core": "2.0.0-rc.1",
+		"@angular/http": "2.0.0-rc.1",
 		"@angular/platform-browser": "2.0.0-rc.1",
 		"@angular/platform-browser-dynamic": "2.0.0-rc.1",
 		"@angular/platform-server": "2.0.0-rc.1",
 		"@angular/router-deprecated": "2.0.0-rc.1",
+		"@angular/router": "2.0.0-rc.1",
 		"@horizon/client": "^1.0.1",
 		"nativescript-angular": "0.1.1",
+		"rxjs": "5.0.0-beta.6",
 		"tns-core-modules": "^2.0.0"
 	},
 	"devDependencies": {

--- a/examples/nativescript-ng2-chat-app/tsconfig.json
+++ b/examples/nativescript-ng2-chat-app/tsconfig.json
@@ -4,9 +4,7 @@
         "target": "es5",
         "sourceMap": true,
         "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
-        "noEmitHelpers": true,
-        "noEmitOnError": true
+        "emitDecoratorMetadata": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Ok @triniwiz this will get it working for you. Follow these steps after merging and pulling latest down:

```
cd examples/nativescript-ng2-chat-app
rm -rf platforms node_modules
npm i
```

Then ensure your Horizon server is running so go ahead and start that in different terminal window.
Then:

```
tns emulate ios
// or
tns emulate android
```
Or use the VS Code debugger for NativeScript.

I'll explain more tomorrow what the issue was and why.
